### PR TITLE
Tweaks to accommodate launching events-api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM node:8.10-stretch
 
-RUN npm install -g serverless
+RUN npm install -g serverless serverless-domain-manager serverless-offline

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ export
 build:
 	docker build . -t serverless_toolbox
 
+npminstall:
+	docker run --rm -i -t \
+	--privileged \
+	-v ${SRC}:/app \
+	-w="/app" \
+	serverless_toolbox \
+	sh -c 'npm install'
+
 ssh:
 	docker run --rm -i -t \
 	--privileged \
@@ -12,9 +20,10 @@ ssh:
 	-e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
 	-e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
 	-e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" \
+	-e MOBILIZE_AMERICA_API_KEY \
+	-e MONGODB_URI \
+	-p "3000:3000" \
 	serverless_toolbox \
 	bash
 
-toolbox:
-	make build
-	make ssh
+toolbox: build npminstall ssh


### PR DESCRIPTION
- export more env vars
- ensure npm install is run
- map port 3000 for `serverless offline`